### PR TITLE
Develop

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -36,7 +36,7 @@ Use .dir-locals.el to set the connection information for the current project
       (host ."127.0.0.1")
       (user ."username")
       (password ."password")
-      (remote_path ."/www") ;;Remote server engineering path 
+      (remote-path ."/www") ;;Remote server engineering path 
       (port ."22")
     ))
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
       (host ."127.0.0.1")
       (user ."username")
       (password ."password")
-      (remote_path ."/www") ;;远程项目路径
+      (remote-path ."/www") ;;远程项目路径
       (port ."22")
     ))
 

--- a/scp.el
+++ b/scp.el
@@ -43,17 +43,17 @@
       (goto-char (point-min)))
     (switch-to-buffer-other-window scp-buffer-name)))
 
-(defun scp-remote-file-path(local_path)
+(defun scp-remote-file-path(local-path)
   "String replacement to get the remote file path"
   (replace-regexp-in-string (locate-dominating-file default-directory dir-locals-file)
-			    (concat (scp-get-alist 'remote_path) "/")
-			    local_path))
+			    (concat (scp-get-alist 'remote-path) "/")
+			    local-path))
 
 (cl-defun scp-get-alist(key &optional (alist file-local-variables-alist))
   "Gets the value of the Association List"
   (cdr (assoc key alist)))
 
-(defun scp-cmd(status &optional local_path)
+(defun scp-cmd(status &optional local-path)
   "Stitching scp command"
   (hack-dir-local-variables)
   (let* ((host (scp-get-alist 'host))
@@ -62,16 +62,16 @@
 	 (pw (scp-get-alist 'password))
 	 (cmd (concat (unless (memq system-type '(windows-nt ms-dos))
 			(format "sshpass -p %s " pw))
-		      scp-tools  (unless (eq local_path buffer-file-name) " -r")
+		      scp-tools  (unless (eq local-path buffer-file-name) " -r")
 		      (concat " -P " port " "
 			      (when (memq system-type '(windows-nt ms-dos))
 				(format "-pw %s " pw)))))
-	 (remote_path (concat (scp-remote-file-path local_path)
-			      (if (and (not (eq local_path buffer-file-name)) (string-equal status "get"))
+	 (remote-path (concat (scp-remote-file-path local-path)
+			      (if (and (not (eq local-path buffer-file-name)) (string-equal status "get"))
 				  "*")))
 	 (cmd_list (if (string= status "put")
-		       (format "%s %s@%s:%s" local_path user host remote_path)
-		     (format "%s@%s:%s %s" user host remote_path local_path))))
+		       (format "%s %s@%s:%s" local-path user host remote-path)
+		     (format "%s@%s:%s %s" user host remote-path local-path))))
     (concat cmd cmd_list)))
 
 (cl-defun scp(status &optional (directory buffer-file-name))

--- a/scp.el
+++ b/scp.el
@@ -46,7 +46,8 @@
 (defun scp-remote-file-path(local-path)
   "String replacement to get the remote file path"
   (replace-regexp-in-string (locate-dominating-file default-directory dir-locals-file)
-			    (concat (scp-get-alist 'remote-path) "/")
+			    (concat
+			     (shell-quote-argument (scp-get-alist 'remote-path)) "/")
 			    local-path))
 
 (cl-defun scp-get-alist(key &optional (alist file-local-variables-alist))

--- a/scp.el
+++ b/scp.el
@@ -51,19 +51,15 @@
 
 (cl-defun scp-get-alist(key &optional (alist file-local-variables-alist))
   "Gets the value of the Association List"
-  (cdr (assoc key alist)))
+  (shell-quote-argument (cdr (assoc key alist))))
 
 (defun scp-cmd(status &optional local-path)
   "Stitching scp command"
   (hack-dir-local-variables)
-  (let* ((host
-	  (shell-quote-argument (scp-get-alist 'host)))
-	 (user
-	  (shell-quote-argument (scp-get-alist 'user)))
-	 (port
-	  (shell-quote-argument (scp-get-alist 'port)))
-	 (pw
-	  (shell-quote-argument (scp-get-alist 'password)))
+  (let* ((host (scp-get-alist 'host))
+	 (user (scp-get-alist 'user))
+	 (port (scp-get-alist 'port))
+	 (pw (scp-get-alist 'password))
 	 (cmd (concat (unless (memq system-type '(windows-nt ms-dos))
 			(format "sshpass -p %s " pw))
 		      scp-tools  (unless (eq local-path buffer-file-name) " -r")

--- a/scp.el
+++ b/scp.el
@@ -56,10 +56,14 @@
 (defun scp-cmd(status &optional local-path)
   "Stitching scp command"
   (hack-dir-local-variables)
-  (let* ((host (scp-get-alist 'host))
-	 (user (scp-get-alist 'user))
-	 (port (scp-get-alist 'port))
-	 (pw (scp-get-alist 'password))
+  (let* ((host
+	  (shell-quote-argument (scp-get-alist 'host)))
+	 (user
+	  (shell-quote-argument (scp-get-alist 'user)))
+	 (port
+	  (shell-quote-argument (scp-get-alist 'port)))
+	 (pw
+	  (shell-quote-argument (scp-get-alist 'password)))
 	 (cmd (concat (unless (memq system-type '(windows-nt ms-dos))
 			(format "sshpass -p %s " pw))
 		      scp-tools  (unless (eq local-path buffer-file-name) " -r")

--- a/scp.el
+++ b/scp.el
@@ -46,8 +46,7 @@
 (defun scp-remote-file-path(local-path)
   "String replacement to get the remote file path"
   (replace-regexp-in-string (locate-dominating-file default-directory dir-locals-file)
-			    (concat
-			     (shell-quote-argument (scp-get-alist 'remote-path)) "/")
+			    (concat (scp-get-alist 'remote-path) "/")
 			    local-path))
 
 (cl-defun scp-get-alist(key &optional (alist file-local-variables-alist))

--- a/scp.el
+++ b/scp.el
@@ -45,7 +45,8 @@
 
 (defun scp-remote-file-path(local-path)
   "String replacement to get the remote file path"
-  (replace-regexp-in-string (locate-dominating-file default-directory dir-locals-file)
+  (replace-regexp-in-string (regexp-quote
+			     (locate-dominating-file default-directory dir-locals-file))
 			    (concat (scp-get-alist 'remote-path) "/")
 			    local-path))
 

--- a/scp.el
+++ b/scp.el
@@ -17,6 +17,10 @@
 
 (require 'cl-lib)
 
+(define-derived-mode scp-mode special-mode "Scp"
+  "Major mode for viewing Scp result."
+  (read-only-mode 1))
+
 (defconst scp-tools
   (if (memq system-type '(windows-nt ms-dos))
       "pscp"
@@ -27,21 +31,9 @@
   "Result Buffer name."
   :type 'string)
 
-(define-derived-mode scp-mode org-mode "Scp"
-  "Major mode for viewing Scp result."
-  (read-only-mode 1)
-  (define-key scp-mode-map "q" 'quit-window))
-
-(defun scp-locals-init()
-  "Get local variables"
-  (setq enable-local-variables :all enable-local-eval t)
-  (hack-dir-local-variables))
-
 (defun scp-exist-dir-locals-file()
   "Determine whether the dir-local -file file exists"
   (file-exists-p (concat (locate-dominating-file default-directory dir-locals-file) dir-locals-file)))
-
-;; (scp-locals-init)
 
 (defun scp-show-in-buffer()
   (with-current-buffer (get-buffer-create scp-buffer-name)
@@ -63,7 +55,7 @@
 
 (defun scp-cmd(status &optional local_path)
   "Stitching scp command"
-  (scp-locals-init)
+  (hack-dir-local-variables)
   (let* ((host (scp-get-alist 'host))
 	 (user (scp-get-alist 'user))
 	 (port (scp-get-alist 'port))

--- a/scp.el
+++ b/scp.el
@@ -56,14 +56,10 @@
 (defun scp-cmd(status &optional local-path)
   "Stitching scp command"
   (hack-dir-local-variables)
-  (let* ((host
-	  (shell-quote-argument (scp-get-alist 'host)))
-	 (user
-	  (shell-quote-argument (scp-get-alist 'user)))
-	 (port
-	  (shell-quote-argument (scp-get-alist 'port)))
-	 (pw
-	  (shell-quote-argument (scp-get-alist 'password)))
+  (let* ((host (scp-get-alist 'host))
+	 (user (scp-get-alist 'user))
+	 (port (scp-get-alist 'port))
+	 (pw (scp-get-alist 'password))
 	 (cmd (concat (unless (memq system-type '(windows-nt ms-dos))
 			(format "sshpass -p %s " pw))
 		      scp-tools  (unless (eq local-path buffer-file-name) " -r")

--- a/scp.el
+++ b/scp.el
@@ -102,13 +102,13 @@
 (defun scp-get-directory(root)
   "Download the folder"
   (interactive "DLocal directory: ")
-  (scp "get" root))
+  (scp "get" (shell-quote-argument root)))
 
 ;;;###autoload
 (defun scp-put-directory(root)
   "Upload folder"
   (interactive "DLocal directory: ")
-  (scp "put" root))
+  (scp "put" (shell-quote-argument root)))
 
 (provide 'scp)
 


### PR DESCRIPTION
Rename the variable `remote_path` to `remote-path` .
Replace `org-mode` with `special-mode` .
`replace-regexp-in-string` is used to handle regular expressions using `regexp-quote` .
Use `shell-quote-argument` to handle external variables